### PR TITLE
Fix the build for Mac OS X

### DIFF
--- a/checkfil.c
+++ b/checkfil.c
@@ -10,9 +10,9 @@
 #include <ctype.h>
 #include <fcntl.h>
 #include <sys/types.h>
-/*
+
 #include <sys/stat.h>
-*/
+
 #include <errno.h>
 #include "checkfil.h"
 

--- a/newmgrep.c
+++ b/newmgrep.c
@@ -16,9 +16,7 @@
 #include <sys/types.h>
 #endif
 
-#ifdef _WIN32
 #include <sys/stat.h>
-#endif
 
 #include "agrep.h"
 #include "codepage.h"

--- a/recursiv.c
+++ b/recursiv.c
@@ -62,9 +62,7 @@
 int  exec();    /* agrep.c */
 #endif
 
-/*
- * #include <sys/stat.h>
- */
+#include <sys/stat.h>
 #include <fcntl.h>
 #define BUFSIZE 256
 #define DIRSIZE 14


### PR DESCRIPTION
Hi, as has been pointed out in some issues, the build process is not working for Mac OS X at the moment. This patch fixes the problem for Mac by uncommenting the stat.h imports in several files. I'm not sure why they were commented, though, so it would be best to test that this doesn't break the build on any other system.