### PR TITLE
Enable OSX El Capitan build

### DIFF
--- a/checkfil.c
+++ b/checkfil.c
@@ -10,9 +10,9 @@
 #include <ctype.h>
 #include <fcntl.h>
 #include <sys/types.h>
-/*
-#include <sys/stat.h>
-*/
+#ifdef __APPLE__
+    #include <sys/stat.h>
+#endif
 #include <errno.h>
 #include "checkfil.h"
 

--- a/newmgrep.c
+++ b/newmgrep.c
@@ -16,8 +16,8 @@
 #include <sys/types.h>
 #endif
 
-#ifdef _WIN32
-#include <sys/stat.h>
+#if defined(_WIN32) || defined(__APPLE__)
+    #include <sys/stat.h>
 #endif
 
 #include "agrep.h"

--- a/recursiv.c
+++ b/recursiv.c
@@ -53,6 +53,10 @@
 
 #endif
 
+#ifdef __APPLE__
+    #include <sys/stat.h>
+#endif
+
 #ifdef _WIN32
 #include "config.h"
 #include <string.h>


### PR DESCRIPTION
Another fix for the Max OSX build for issue #7 however this PR includes ifdef options that mean the current build is completely preserved for all other platforms and only Apple get the additional explicit include for <sys/stat.h>