### PR TITLE
Adjust wording and formatting in help text

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ AGREP [-#cdehi[a|#]klnprstvwxyABDGIRS] [-f patternfile] [-H dir] pattern [files]
 -l  output the names of files that contain a match
 -n  print line numbers of matches          -q  print buffer byte offsets
 -p  supersequence search                   -CP 850|437 set codepage
--r  recurse subdirectories (UNIX style)    -s silent
+-r  recurse subdirectories (UNIX style)    -s  silent
 -t  for use when delimiter is at the end of records
 -v  output those records without matches   -V[012345V] version / verbose more
 -w  pattern has to match as a word: "win" will not match "wind"

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ AGREP [-#cdehi[a|#]klnprstvwxyABDGIRS] [-f patternfile] [-H dir] pattern [files]
 -v  output those records without matches   -V[012345V] version / verbose more
 -w  pattern has to match as a word: "win" will not match "wind"
 -u  suppress record output                 -x  pattern must match a whole line
--y  suppresses the prompt when used with -B best match option
+-y  suppress the prompt when used with -B best match option
 @listfile  use the filenames in listfile                              <1>23456Q
 ```
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ AGREP [-#cdehi[a|#]klnprstvwxyABDGIRS] [-f patternfile] [-H dir] pattern [files]
 -i# digits-match-digits, letters-letters   -i0 case-sensitive search
 -k  treat pattern literally - no meta-characters
 -l  output the names of files that contain a match
--n  print line numbers of matches  -q print buffer byte offsets
+-n  print line numbers of matches          -q  print buffer byte offsets
 -p  supersequence search                   -CP 850|437 set codepage
 -r  recurse subdirectories (UNIX style)    -s silent
 -t  for use when delimiter is at the end of records

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ AGREP [-#cdehi[a|#]klnprstvwxyABDGIRS] [-f patternfile] [-H dir] pattern [files]
 -t  for use when delimiter is at the end of records
 -v  output those records without matches   -V[012345V] version / verbose more
 -w  pattern has to match as a word: "win" will not match "wind"
--u  unterdruecke record output             -x  pattern must match a whole line
+-u  suppress record output                 -x  pattern must match a whole line
 -y  suppresses the prompt when used with -B best match option
 @listfile  use the filenames in listfile                              <1>23456Q
 ```

--- a/agrep.c
+++ b/agrep.c
@@ -579,7 +579,7 @@ int Text, M, D;
 					}
 					r3 = Init0;
 					r2 = ((Next[r3>>hh] | Next1[r3&LL]) & CMask) | Init0;
-					/* match begin of line */
+					/* match beginning of line */
 					if (DELIMITER) CurrentByteOffset += 1*D_length;
 					else CurrentByteOffset += 1*1;
 				}
@@ -636,7 +636,7 @@ int Text, M, D;
 					}
 					r2 = Init0;
 					r3 = ((Next[r2>>hh] | Next1[r2&LL]) & CMask) | Init0;
-					/* match begin of line */
+					/* match beginning of line */
 					if (DELIMITER) CurrentByteOffset += 1*D_length;
 					else CurrentByteOffset += 1*1;
 				}
@@ -714,7 +714,7 @@ int Text, M, D;
 					}
 					r3 = Init0;
 					r2 = ((Next[r3>>hh] | Next1[r3&LL]) & CMask) | Init0;
-					/* match begin of line */
+					/* match beginning of line */
 					if (DELIMITER) CurrentByteOffset += 1*D_length;
 					else CurrentByteOffset += 1*1;
 				}
@@ -771,7 +771,7 @@ int Text, M, D;
 					}
 					r2 = Init0;
 					r3 = ((Next[r2>>hh] | Next1[r2&LL]) & CMask) | Init0;
-					/* match begin of line */
+					/* match beginning of line */
 					if (DELIMITER) CurrentByteOffset += 1*D_length;
 					else CurrentByteOffset += 1*1;
 				}

--- a/agrep.h
+++ b/agrep.h
@@ -79,7 +79,7 @@
 #define STAR      145   /* closure */
 #define HYPHEN    129   /* - */
 #define NOCARE    130   /* . */
-#define NNLINE    131   /* special symbol for newline in begin of pattern*/
+#define NNLINE    131   /* special symbol for newline in beginning of pattern */
 					   /* matches '\n' and NNLINE */
 #define USERRANGE_MIN 128 	/* min char in pattern of user: give warning */
 #define USERRANGE_MAX 145	/* max char in pattern of user: give warning */
@@ -117,7 +117,7 @@ extern unsigned char metasymb[16];
 #define STAR      metasymb[12]	/* * closure */
 #define HYPHEN    metasymb[13]	/* - */
 #define NOCARE    metasymb[14]	/* . */
-#define NNLINE    metasymb[15]	/* special symbol for newline in begin of pattern*/
+#define NNLINE    metasymb[15]	/* special symbol for newline in beginning of pattern */
 				/* matches '\n' and NNLINE */
 
 /* not used anymore: [TG] */			

--- a/agrephlp.c
+++ b/agrephlp.c
@@ -140,7 +140,7 @@ fprintf(stderr,"-r  recurse subdirectories (UNIX style)    -s  silent\n");
 fprintf(stderr,"-t  for use when delimiter is at the end of records\n");
 fprintf(stderr,"-v  output those records without matches   -V[012345V] version / verbose more\n");
 fprintf(stderr,"-w  pattern has to match as a word: \"win\" will not match \"wind\"\n");
-fprintf(stderr,"-u  unterdruecke record output             -x  pattern must match a whole line\n");
+fprintf(stderr,"-u  suppress record output                 -x  pattern must match a whole line\n");
 fprintf(stderr,"-y  suppresses the prompt when used with -B best match option\n");
 fprintf(stderr,"@listfile  use the filenames in listfile                              <1>23456Q");
 

--- a/agrephlp.c
+++ b/agrephlp.c
@@ -149,7 +149,7 @@ userw;
 PAGE2:
 one_line_help();
 fprintf(stderr,"\nThe pattern MUST BE ENCLOSED in \"DOUBLE QUOTES\" if it contains one of the\n");
-fprintf(stderr,"following METASYMBOLS. Good practice is always to include it in double quotes.\n\n");
+fprintf(stderr,"following METASYMBOLS. Good practice is always to enclose it in double quotes.\n\n");
 
 fprintf(stderr,"METASYMBOLS:\n");
 fprintf(stderr,"\\z          turns off any special meaning of character z (\\# matches #)\n");

--- a/agrephlp.c
+++ b/agrephlp.c
@@ -153,7 +153,7 @@ fprintf(stderr,"following METASYMBOLS. Good practice is always to enclose it in 
 
 fprintf(stderr,"METASYMBOLS:\n");
 fprintf(stderr,"\\z          turns off any special meaning of character z (\\# matches #)\n");
-fprintf(stderr,"^           begin-of-line symbol\n");
+fprintf(stderr,"^           beginning-of-line symbol\n");
 fprintf(stderr,"$           end-of-line symbol\n");
 fprintf(stderr,".           matches any single character (except newline)\n");
 fprintf(stderr,"#           matches any number > 0 of arbitrary characters\n");

--- a/agrephlp.c
+++ b/agrephlp.c
@@ -141,7 +141,7 @@ fprintf(stderr,"-t  for use when delimiter is at the end of records\n");
 fprintf(stderr,"-v  output those records without matches   -V[012345V] version / verbose more\n");
 fprintf(stderr,"-w  pattern has to match as a word: \"win\" will not match \"wind\"\n");
 fprintf(stderr,"-u  suppress record output                 -x  pattern must match a whole line\n");
-fprintf(stderr,"-y  suppresses the prompt when used with -B best match option\n");
+fprintf(stderr,"-y  suppress the prompt when used with -B best match option\n");
 fprintf(stderr,"@listfile  use the filenames in listfile                              <1>23456Q");
 
 userw;

--- a/agrephlp.c
+++ b/agrephlp.c
@@ -134,7 +134,7 @@ fprintf(stderr,"-i  case-insensitive search; ISO <> ASCII  -ia ISO chars mapped 
 fprintf(stderr,"-i# digits-match-digits, letters-letters   -i0 case-sensitive search\n");
 fprintf(stderr,"-k  treat pattern literally - no meta-characters\n");
 fprintf(stderr,"-l  output the names of files that contain a match\n");
-fprintf(stderr,"-n  print line numbers of matches  -q print buffer byte offsets\n");
+fprintf(stderr,"-n  print line numbers of matches          -q  print buffer byte offsets\n");
 fprintf(stderr,"-p  supersequence search                   -CP 850|437 set codepage\n");
 fprintf(stderr,"-r  recurse subdirectories (UNIX style)    -s silent\n");
 fprintf(stderr,"-t  for use when delimiter is at the end of records\n");

--- a/agrephlp.c
+++ b/agrephlp.c
@@ -229,7 +229,7 @@ if ((cpage=get_current_codepage()) != -1) fprintf(stderr,"is CP %d.\n\n",cpage);
 else fprintf(stderr,"could not be detected. AGREP will use CP850 by default.\n\n");
 
 fprintf(stderr,"   The codepage setting affects the uppercase-lowercase translation table\n");
-fprintf(stderr,"   built-in AGREP when you use one of the options -i, -ia or -i# .\n");
+fprintf(stderr,"   built into AGREP when you use one of the options -i, -ia or -i# .\n");
 fprintf(stderr,"   The translation table can be printed by using verbose option -V5.\n\n");
 
 fprintf(stderr,"The default verbose option is %d                                       123<4>56Q",VERBOSE);

--- a/agrephlp.c
+++ b/agrephlp.c
@@ -136,7 +136,7 @@ fprintf(stderr,"-k  treat pattern literally - no meta-characters\n");
 fprintf(stderr,"-l  output the names of files that contain a match\n");
 fprintf(stderr,"-n  print line numbers of matches          -q  print buffer byte offsets\n");
 fprintf(stderr,"-p  supersequence search                   -CP 850|437 set codepage\n");
-fprintf(stderr,"-r  recurse subdirectories (UNIX style)    -s silent\n");
+fprintf(stderr,"-r  recurse subdirectories (UNIX style)    -s  silent\n");
 fprintf(stderr,"-t  for use when delimiter is at the end of records\n");
 fprintf(stderr,"-v  output those records without matches   -V[012345V] version / verbose more\n");
 fprintf(stderr,"-w  pattern has to match as a word: \"win\" will not match \"wind\"\n");

--- a/maskgen.c
+++ b/maskgen.c
@@ -225,7 +225,7 @@ int D;
 	Init[0] = Init[0] | endposition;
 	
 	/* not necessary for INit[i], i>0, */
-	/* but at every begining of the matching process append one
+	/* but at every beginning of the matching process append one
 	   no-match character to initialize the error vectors */
 	   
 	endposition = ( endposition << 1 ) + 1;


### PR DESCRIPTION
This PR makes a number of minor changes to wording and formatting, mostly in the help text:

* Fix alignment of -q help text
* Fix alignment of -s help text
* Change "unterdruecke" to "suppress" in -u help text
* Change "suppresses" to "suppress" in -y help text
* Change "include" to "enclose" in help text
* Change "begin of" to "beginning of"
* Change "built-in" to "built into" in help text
